### PR TITLE
[TL-804] keep json fields with nil values for stable CSV columns

### DIFF
--- a/csv_writer_test.go
+++ b/csv_writer_test.go
@@ -45,12 +45,12 @@ func TestKeyWithCapitalizedWords(t *testing.T) {
 	responses := []map[string]interface{}{
 		{
 			"BCDTest":  1,
-			"abcBCD":  "foo",
+			"abcBCD":   "foo",
 			"ABC Test": "FOO",
 		},
 		{
 			"BCDTest":  2,
-			"abcBCD":  "bar",
+			"abcBCD":   "bar",
 			"ABC Test": "BAR",
 		},
 	}
@@ -85,7 +85,6 @@ func TestKeysWithReadableNotationStyle(t *testing.T) {
 	if got != want {
 		t.Errorf("Expected %v, but %v", want, got)
 	}
-
 }
 
 func TestKeysWithInfinitusNotationStyle(t *testing.T) {
@@ -101,9 +100,33 @@ func TestKeysWithInfinitusNotationStyle(t *testing.T) {
 	if got != want {
 		t.Errorf("Expected %v, but %v", want, got)
 	}
-
 }
 
+func TestFieldsWithNilValues(t *testing.T) {
+	b := &bytes.Buffer{}
+	wr := NewCSVWriter(b)
+	responses := []map[string]interface{}{
+		{
+			"A": 1,
+			"B": "foo",
+			"C": nil,
+		},
+	}
+	csvContent, err := JSON2CSV(responses)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wr.WriteCSV(csvContent)
+	wr.Flush()
+
+	got := b.String()
+	want := `/A,/B,/C
+1,foo,null
+`
+	if got != want {
+		t.Errorf("Expected %v, but %v", want, got)
+	}
+}
 
 func writeCSVHelper(style KeyStyle) (string, error) {
 	responses := getTestResponse()
@@ -123,9 +146,9 @@ func writeCSVHelper(style KeyStyle) (string, error) {
 func getTestResponse() []map[string]interface{} {
 	return []map[string]interface{}{
 		{
-			"Test":  1,
-			"thisIsATest":  map[string]interface{}{
-				"withADot": "foo",
+			"Test": 1,
+			"thisIsATest": map[string]interface{}{
+				"withADot":    "foo",
 				"withADotTwo": "foo2",
 				"withAnother": map[string]interface{}{
 					"dot": "foo3",
@@ -144,9 +167,9 @@ func getTestResponse() []map[string]interface{} {
 			},
 		},
 		{
-			"Test":  2,
-			"thisIsATest":  map[string]interface{}{
-				"withADot": "bar",
+			"Test": 2,
+			"thisIsATest": map[string]interface{}{
+				"withADot":    "bar",
 				"withADotTwo": "bar2",
 				"withAnother": map[string]interface{}{
 					"dot": "bar3",

--- a/flatten.go
+++ b/flatten.go
@@ -46,6 +46,12 @@ func flatten(obj interface{}) (KeyValue, error) {
 }
 
 func _flatten(out KeyValue, obj interface{}, key jsonpointer.JSONPointer) error {
+	// Include nil value in the CSV so that the columns do not dependent
+	// on whether the Json field is present or not.
+	if obj == nil {
+		out[key.String()] = "null"
+	}
+
 	value, ok := obj.(reflect.Value)
 	if !ok {
 		value = reflect.ValueOf(obj)


### PR DESCRIPTION
The default behavior of json2csv is to not include the CSV columns if the Json fields have nil values.  This PR updates the "_flatten" utility such that we include fields with nil values.

In order to ensure stable CSV columns, we would like to include the JSON fields with nil values.
For example,
JSON:
```json
{
  "id": 1,
  "age": 21,
  "name": "foo"
}
```
CSV:
```csv
id,age,name
1,21,foo
```
JSON:
```json
{
  "id": 2,
  "age": null,
  "name": "bar"
}
```
CSV
```csv
id,age,name
1,null,foo
```